### PR TITLE
Add the ability to customize the options passed to the Sentry SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## Unreleased
+### Added
+- Add the ability to pass custom options to the Sentry SDK by listening to the 
+  `SentryService::EVENT_DEFINE_SENTRY_SDK_CONFIGURATION` event
+
 ## 1.0.3 - 2020-10-29
 ### Fixed
 - Only set up Sentry after we've made sure we need to process the exception

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 - Add the ability to pass custom options to the Sentry SDK by listening to the 
   `SentryService::EVENT_DEFINE_SENTRY_SDK_CONFIGURATION` event
+- Honor the Craft [`httpProxy` general setting](https://craftcms.com/docs/3.x/config/config-settings.html#httpproxy)
 
 ## 1.0.3 - 2020-10-29
 ### Fixed

--- a/src/events/DefineSentrySdkConfigurationEvent.php
+++ b/src/events/DefineSentrySdkConfigurationEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace statikbe\sentry\events;
+
+use yii\base\Event;
+
+/**
+ * @event The event that is triggered when defining the configuration of the Sentry SDK.
+ */
+class DefineSentrySdkConfigurationEvent extends Event
+{
+    /**
+     * @var array An associative array of options that will be passed to the SentrySdk\init() method.
+     * @link https://docs.sentry.io/platforms/php/configuration/options/
+     */
+    public $options;
+}

--- a/src/services/SentryService.php
+++ b/src/services/SentryService.php
@@ -86,6 +86,7 @@ class SentryService extends Component
                 'dsn'         => $settings->clientDsn,
                 'environment' => CRAFT_ENVIRONMENT,
                 'release'     => $settings->release,
+                'http_proxy'  => \Craft::$app->config->general->httpProxy,
             ],
         ]);
         $this->trigger(self::EVENT_DEFINE_SENTRY_SDK_CONFIGURATION, $event);


### PR DESCRIPTION
Add an event triggered when defining the Sentry SDK configuration to add the ability to add custom options.

Example:

```php
\yii\base\Event::on(
  \statikbe\sentry\services\SentryService::class,
  \statikbe\sentry\services\SentryService::EVENT_DEFINE_SENTRY_SDK_CONFIGURATION,
  function(DefineSentrySdkConfigurationEvent $event) {
    $event->options['context_lines'] = 5;
  }
);
```

This PR also changes the default Sentry SDK options to honor the Craft `httpProxy` general setting, so that the plugin works even behind a proxy if Craft is properly configured..