### PR TITLE
Use a less restrictive version constraint for Craft 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "4.0.0-beta.1",
+        "craftcms/cms": "^4.0.0-beta.1",
         "sentry/sdk": "^3.0.0"
     },
     "autoload": {


### PR DESCRIPTION
This change allows using the craft-sentry plugin with any version of Craft 4